### PR TITLE
[BUGFIX] Fix `g_options` potentially being undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,12 +28,10 @@ module.exports = function GulpParcel(...options)
     const PLUGIN_NAME = 'gulp-parcel';
     const pid = process.pid.toString();
 
-    let g_options;
+    let g_options = {};
     if(options.length > 0) {
         if(options.length > 1) {
             g_options = options[1];
-        } else {
-            g_options = {};
         }
         options = options[0];
     }

--- a/index.js
+++ b/index.js
@@ -51,22 +51,22 @@ module.exports = function GulpParcel(...options)
             cb(null, file);
             return;
         }
-        
-        // slashes on unix os 
+
+        // slashes on unix os
         // backslashes on windows
 		let slashes = '/';
-		
+
 		if( file.path.lastIndexOf(slashes) === -1){
 			slashes = '\\';
         }
-        
+
         let out_flname;
         if(g_options.source && !isTmp) {
             out_flname = file.path.replace(source, options.outDir);
         } else {
             out_flname = options.outDir + slashes + file.path.substr(file.path.lastIndexOf(slashes) + 1);
         }
-        
+
         let options_c = {}, outDir;
         Object.assign(options_c, options);
         outDir = file.path.substr(file.path.lastIndexOf(source));
@@ -97,7 +97,7 @@ module.exports = function GulpParcel(...options)
                 this.emit('error', new PluginError(PLUGIN_NAME, "Build FAIL:" + file.path));
                 cb(null, file);
             }
-			
+
 			// In case dealing with Pug files
 			// at this stage Pub files should've been transformed to html
 			if( out_flname.substr(out_flname.lastIndexOf('.') + 1).trim().toLowerCase() === 'pug' ){
@@ -114,7 +114,7 @@ module.exports = function GulpParcel(...options)
                     file.contents = data;
                     this.push(file);
                     if(options.production && isTmp) {
-                        removeDirectory(options.outDir);                
+                        removeDirectory(options.outDir);
                     }
                     cb(null, file);
                 });


### PR DESCRIPTION
Previously, if no options were passed to gulp-parcel, it would crash upon trying to access `g_options.source` on line 46 of index.js: https://github.com/zacky1972/gulp-parcel/blob/5d5fe50d0fd39f79a860e0341a93ce986a5e6615/index.js#L46

This is an example of the output from a crash:

```
[19:42:01] Using gulpfile ./gulpfile.js
[19:42:01] Starting 'clean'...
[19:42:01] Starting 'lint'...
[19:42:01] Starting 'readme'...
[19:42:01] Finished 'clean' after 17 ms
[19:42:02] Finished 'lint' after 593 ms
[19:42:02] Finished 'readme' after 624 ms
[19:42:02] Starting 'build'...
[19:42:02] 'build' errored after 748 μs
[19:42:02] TypeError: Cannot read property 'source' of undefined
    at GulpParcel (./node_modules/gulp-parcel/index.js:46:30)
    at Gulp.gulp.task (./gulpfile.js:61:9)
    at module.exports (./node_modules/orchestrator/lib/runTask.js:34:7)
    at Gulp.Orchestrator._runTask (./node_modules/orchestrator/index.js:273:3)
    at Gulp.Orchestrator._runStep (./node_modules/orchestrator/index.js:214:10)
    at ./node_modules/orchestrator/index.js:279:18
    at finish (./node_modules/orchestrator/lib/runTask.js:21:8)
    at ./node_modules/orchestrator/lib/runTask.js:52:4
    at f (./node_modules/end-of-stream/node_modules/once/once.js:17:25)
    at DestroyableTransform.onend (./node_modules/end-of-stream/index.js:31:18)
```

This PR fixes that issue by assigning an empty object to `g_options` at the time it's declared via `let`, ensuring it is never undefined.