### PR TITLE
Provision to support parcel options serve, port & sourceMaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ call parcel `gulp.src` with options and g_options
 Currently the following options are supported:
 
 * **watch:** *true or false* (default: false)
+* **serve:** *true or false* (default: false)
+* **port:** *numbere* (default: 1234)
+* **sourceMaps:** *true or false* (default: false)
 * **outDir:** *string* (default: temporary directory)
 * **cache:** *true or false* (default: true)
 * **cacheDir:** *true or false* (default: '.cache')

--- a/index.js
+++ b/index.js
@@ -39,6 +39,10 @@ module.exports = function GulpParcel(...options)
     }
 
     options.watch = (typeof(options.watch) == "undefined") ? false : options.watch;
+    options.port = (typeof(options.port) == "undefined" || isNaN(parseInt(options.port)) ) ? undefined : parseInt(options.port);
+    options.serve = (typeof(options.serve) == "undefined") ? false : options.serve;
+    options.sourceMaps = (typeof(options.sourceMaps) == "undefined") ? false : options.sourceMaps;
+
     options.production = (typeof(options.production) == "undefined") ? !options.watch : options.production;
     const isTmp = options.outDir ? false : true;
     options.outDir = options.outDir ? options.outDir : ('.tmp-gulp-compile-' + pid);
@@ -89,7 +93,16 @@ module.exports = function GulpParcel(...options)
         });
 
         const parcel = new parcelBundler(file.path, options_c);
-        parcel.bundle().then(bundle => {
+        let executeParcel;
+
+        //To run parcel server when the server is enabled or port is specified
+        if(options_c.serve || options_c.port) {
+            executeParcel = parcel.serve(options_c.port);
+        } else {
+            executeParcel = parcel.bundle();
+        }
+
+        executeParcel.then(bundle => {
             if(parcel.errored) {
                 if(isTmp) {
                     removeDirectory(options.outDir);
@@ -129,5 +142,3 @@ module.exports = function GulpParcel(...options)
         });
     });
 }
-
-


### PR DESCRIPTION
Fix for the issue, [How to specify port ](https://github.com/zacky1972/gulp-parcel/issues/7)

Enhanced the library to support parcel options **serve, port & sourceMaps**

**Code Snippet**

```
const gulp = require("gulp");
const parcel = require('gulp-parcel');

gulp.task('parcel-bundler', function() {
    gulp
      .src('./src/*.js', { read: false })
      .pipe(parcel({outDir: "dist", port: 8000, sourceMaps: true }))
      .pipe(gulp.dest('dist'))
})
```
**Executed output screenshot for reference,**
![image](https://user-images.githubusercontent.com/5776549/49542160-d098fe00-f8fa-11e8-962c-937a5e944726.png)
